### PR TITLE
Fix unnamed bullet to avoid editor warning

### DIFF
--- a/Assets/Scripts/GunController.cs
+++ b/Assets/Scripts/GunController.cs
@@ -26,6 +26,7 @@ public class GunController : MonoBehaviour
         else
         {
             bullet = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+            bullet.name = "Bullet";
             bullet.transform.position = firePoint.position;
             bullet.transform.rotation = firePoint.rotation;
             bullet.transform.localScale = Vector3.one * 0.1f;


### PR DESCRIPTION
## Summary
- give default bullets an explicit name

## Testing
- `apt-get update`
- `apt-get install -y vim-common`

------
https://chatgpt.com/codex/tasks/task_e_684d6e783810832b9126d781cadf1312